### PR TITLE
Improve reliability of spuriousSSM calls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+build/
+*.egg-info
+peppercompiler/_spuriousSSM

--- a/peppercompiler/_spuriousSSM_wrapper.py
+++ b/peppercompiler/_spuriousSSM_wrapper.py
@@ -1,8 +1,8 @@
 import sys
-import os
+import subprocess
 import pkg_resources
 
 def main():
     binary_path = pkg_resources.resource_filename(__name__,'_spuriousSSM')
 
-    os.system(binary_path + " " + " ".join(sys.argv[1:]))
+    subprocess.run([binary_path]+sys.argv[1:])

--- a/peppercompiler/design/spurious_design.py
+++ b/peppercompiler/design/spurious_design.py
@@ -8,6 +8,7 @@ import os
 import string
 import subprocess
 import sys
+import pkg_resources
 
 from .constraint_load import Convert
 
@@ -23,7 +24,7 @@ def print_list(xs, filename, format):
     f.write(format % x)
   f.close()
 
-def design(basename, infilename, outfilename, cleanup=True, verbose=False, reuse=False, just_files=False, struct_orient=False, old_output=False, tempname=None, extra_pars="", findmfe=True, spuriousbinary="spuriousSSM"):
+def design(basename, infilename, outfilename, cleanup=True, verbose=False, reuse=False, just_files=False, struct_orient=False, old_output=False, tempname=None, extra_pars=tuple(), findmfe=True, spuriousbinary="spuriousSSM"):
   
   if not tempname:
     tempname = basename
@@ -80,11 +81,14 @@ def design(basename, infilename, outfilename, cleanup=True, verbose=False, reuse
     
     spo = open(sp_outname,'wb') 
     
-    command = "%s score=automatic template=%s wc=%s eq=%s %s %s" % (spuriousbinary, stname, wcname, eqname, extra_pars, quiet)
-    print(command)
+    sp_binary_path = pkg_resources.resource_filename('peppercompiler','_spuriousSSM')
+    if isinstance(extra_pars, str):
+      extra_pars = extra_pars.split()
+    args = [sp_binary_path, f"template={stname}", f"wc={wcname}", f"eq={eqname}"] + list(extra_pars) + [quiet]
+    print(args)
     if just_files:
       return
-    spurious_proc = subprocess.Popen(command, shell=True, stdout=subprocess.PIPE)
+    spurious_proc = subprocess.Popen(args, shell=False, stdout=subprocess.PIPE)
 
     data = spurious_proc.stdout.readline()
     while data:
@@ -162,6 +166,6 @@ def main():
     options.output = basename + ".mfe"
   
   # Collect extra arguments for spuriousSSM
-  spurious_pars = " ".join(args[1:])
+  spurious_pars = args[1:]
   
   design(basename, infilename, options.output, options.cleanup, options.verbose, options.reuse, options.just_files, options.struct_orient, options.old_output, options.tempname, spurious_pars)

--- a/peppercompiler/design/spurious_design.py
+++ b/peppercompiler/design/spurious_design.py
@@ -9,6 +9,7 @@ import string
 import subprocess
 import sys
 import pkg_resources
+import shlex
 
 from .constraint_load import Convert
 
@@ -24,7 +25,8 @@ def print_list(xs, filename, format):
     f.write(format % x)
   f.close()
 
-def design(basename, infilename, outfilename, cleanup=True, verbose=False, reuse=False, just_files=False, struct_orient=False, old_output=False, tempname=None, extra_pars=tuple(), findmfe=True, spuriousbinary="spuriousSSM"):
+def design(basename, infilename, outfilename, cleanup=True, verbose=False, reuse=False, just_files=False, struct_orient=False, 
+           old_output=False, tempname=None, extra_pars=tuple(), findmfe=True, spuriousbinary="spuriousSSM"):
   
   if not tempname:
     tempname = basename
@@ -80,12 +82,18 @@ def design(basename, infilename, outfilename, cleanup=True, verbose=False, reuse
       quiet = "quiet=TRUE"
     
     spo = open(sp_outname,'wb') 
-    
-    sp_binary_path = pkg_resources.resource_filename('peppercompiler','_spuriousSSM')
+
+    if spuriousbinary is None:
+      sp_binary_path = pkg_resources.resource_filename(
+        "peppercompiler", "_spuriousSSM"
+        )
+    else:
+      sp_binary_path = spuriousbinary
     if isinstance(extra_pars, str):
-      extra_pars = extra_pars.split()
-    args = [sp_binary_path, f"template={stname}", f"wc={wcname}", f"eq={eqname}"] + list(extra_pars) + [quiet]
-    print(args)
+        extra_pars = shlex.split(extra_pars)
+    args = [sp_binary_path, "score=automatic", f"template={stname}", f"wc={wcname}", 
+            f"eq={eqname}"] + list(extra_pars) + [quiet]
+    print(shlex.join(args))
     if just_files:
       return
     spurious_proc = subprocess.Popen(args, shell=False, stdout=subprocess.PIPE)

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 from setuptools import setup
-from distutils.command.build import build
+from setuptools.command.build import build
 from setuptools.command.develop import develop
 
 

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ class develop_with_spurious(develop):
 
 setup(
     name="peppercompiler",
-    version="0.1.3",
+    version="0.1.4",
     packages=['peppercompiler', 'peppercompiler.design'],
     install_requires=["pyparsing", "six"],
     include_package_data=True,


### PR DESCRIPTION
These changes improve both the internal calls to spuriousSSM, now using the binary directly by default, and the wrapper CLI calls.   In both cases, shell arguments should be better parsed, avoiding problems with, eg, spaces.

I'm making this pull request for my own tracking; if you're getting notified of this, you don't need to do anything.  I'll push it to the main branch when it is ready.